### PR TITLE
Make inventory plugin work with ansible-doc

### DIFF
--- a/collections_hello_world/collections/ansible_collections/redhat/cmeyers/plugins/inventory/my_inventory.py
+++ b/collections_hello_world/collections/ansible_collections/redhat/cmeyers/plugins/inventory/my_inventory.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     inventory: my_inventory
     short_description: Add a single host
+    description: This plugin adds a single host specified by the hostname option
     options:
       plugin:
         description: plugin name (must be my_inventory)
@@ -52,4 +53,3 @@ class InventoryModule(BaseInventoryPlugin):
         # self.inventory.add_group()...
         # self.inventory.add_child()...
         # self.inventory.set_variable()..
-


### PR DESCRIPTION
This makes it so that this command works

```
ansible-doc -M collections/ansible_collections/redhat/cmeyers/plugins/inventory/ -t inventory my_inventory
> MY_INVENTORY    (/Users/alancoding/Documents/repos/ansible-examples/collections_hello_world/collections/ansible_collections/redhat/cmeyers/plugins/inventory/my_inventory.py)

        This plugin adds a single host specified by the hostname option

  * This module is maintained by The Ansible Community
OPTIONS (= is mandatory):

- hostname
        Toggle display of stderr even when script was successful
        [Default: (null)]
        type: list

= plugin
        plugin name (must be my_inventory)



        METADATA:
          status:
          - preview
          supported_by: community
        

```

before it threw an error that description was missing